### PR TITLE
Add theme toggle to header

### DIFF
--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -2,6 +2,7 @@ import { TerminalIcon } from "@/components/ui/terminal";
 import Image from "next/image";
 import Link from "next/link";
 import { MouseEventHandler } from "react";
+import ThemeToggle from "./theme-toggle";
 type Props = {
   handleabout: MouseEventHandler<HTMLDivElement>;
   handlecontact: MouseEventHandler<HTMLDivElement>;
@@ -26,7 +27,7 @@ export function Headers({ handleabout, handlecontact, lang }: Props) {
           </div>
         </div>
       </Link>
-      <div className="flex gap-4">
+      <div className="flex gap-4 items-center">
         {/* button 1 */}
         <div
           onClick={handleabout}
@@ -41,6 +42,7 @@ export function Headers({ handleabout, handlecontact, lang }: Props) {
         >
           {lang === `mn` ? "Холбогдох" : "Contact"}
         </div>
+        <ThemeToggle />
       </div>
     </div>
   );

--- a/src/app/_components/theme-toggle.tsx
+++ b/src/app/_components/theme-toggle.tsx
@@ -1,0 +1,17 @@
+'use client'
+import { useTheme } from 'next-themes'
+import { useEffect, useState } from 'react'
+import { FaSun, FaMoon } from 'react-icons/fa'
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => setMounted(true), [])
+  if (!mounted) return null
+  const toggle = () => setTheme(theme === 'light' ? 'dark' : 'light')
+  return (
+    <button onClick={toggle} aria-label="Toggle theme" className="p-2 border rounded-md">
+      {theme === 'light' ? <FaMoon /> : <FaSun />}
+    </button>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono, LXGW_WenKai_TC } from "next/font/google";
 import "./globals.css";
 import Image from "next/image";
 import { Suspense } from "react";
+import { Providers } from "./providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,19 +31,21 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased dark ${montserrate.className} overflow-x-hidden`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased ${montserrate.className} overflow-x-hidden`}
       >
-        <div className="fixed z-0">
-          <Image
-            src={`/img/Background-Pattern.svg`}
-            alt="background pattern"
-            width={10000}
-            height={10000}
-          />
-        </div>
-        <div className="z-1 relative w-full">
-          <Suspense fallback={<div>Please wait...</div>}>{children}</Suspense>
-        </div>
+        <Providers>
+          <div className="fixed z-0">
+            <Image
+              src={`/img/Background-Pattern.svg`}
+              alt="background pattern"
+              width={10000}
+              height={10000}
+            />
+          </div>
+          <div className="z-1 relative w-full">
+            <Suspense fallback={<div>Please wait...</div>}>{children}</Suspense>
+          </div>
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased ${montserrate.className} overflow-x-hidden`}
       >

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { ThemeProvider } from 'next-themes'
+import { ReactNode } from 'react'
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
+      {children}
+    </ThemeProvider>
+  )
+}


### PR DESCRIPTION
## Summary
- introduce a `Providers` component to handle theme state
- add a `ThemeToggle` component
- integrate theme toggle in the header
- wrap the layout with the `ThemeProvider`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f26fed348320b7e245c9ac7cfae0